### PR TITLE
Add trait for error registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,9 +1393,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1924,9 +1924,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2379,9 +2379,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -2578,6 +2578,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3629,13 +3630,14 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-trait",
  "getrandom 0.2.16",
  "once_cell",
  "reqwest 0.11.27",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.11.27", features = ["json"] }
 serde_json = "1.0.111"
 thiserror = "1.0.56"
 serde = "1.0.195"
+async-trait = "0.1"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.11", features = ["js", "js-sys"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0.111"
 thiserror = "1.0.56"
 serde = "1.0.195"
 async-trait = "0.1"
+url = "2.5.7"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.11", features = ["js", "js-sys"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use alloy::json_abi::Error as AlloyError;
 use alloy::primitives::hex::{decode, encode, encode_prefixed, FromHexError};
 use alloy::primitives::U256;
 use alloy::rpc::json_rpc::ErrorPayload;
+use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use reqwest::{Client, Error as ReqwestError};
 use serde_json::Value;
@@ -13,6 +14,62 @@ use std::{
 use thiserror::Error;
 
 pub const SELECTOR_REGISTRY_URL: &str = "https://api.openchain.xyz/signature-database/v1/lookup";
+
+/// Trait for pluggable error selector registries.
+///
+/// Implement this trait to provide alternative lookup sources
+/// (e.g. local cache, different HTTP service, bundled table).
+#[async_trait]
+pub trait ErrorRegistry: Send + Sync {
+    /// Lookup candidate ABI errors for a given 4-byte selector.
+    async fn lookup(&self, selector: [u8; 4]) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors>;
+}
+
+/// Default OpenChain-backed registry implementation.
+pub struct OpenChainRegistry {
+    client: Client,
+    url: String,
+}
+
+impl Default for OpenChainRegistry {
+    fn default() -> Self {
+        Self {
+            client: Client::builder().build().expect("reqwest client"),
+            url: SELECTOR_REGISTRY_URL.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl ErrorRegistry for OpenChainRegistry {
+    async fn lookup(&self, selector: [u8; 4]) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors> {
+        let selector_hash = alloy::primitives::hex::encode_prefixed(selector);
+        let response = self
+            .client
+            .get(&self.url)
+            .query(&vec![
+                ("function", selector_hash.as_str()),
+                ("filter", "true"),
+            ])
+            .header("accept", "application/json")
+            .send()
+            .await?
+            .json::<Value>()
+            .await?;
+
+        let mut out: Vec<AlloyError> = Vec::new();
+        if let Some(selectors) = response["result"]["function"][selector_hash].as_array() {
+            for opt_selector in selectors {
+                if let Some(name) = opt_selector["name"].as_str() {
+                    if let Ok(err) = name.parse::<AlloyError>() {
+                        out.push(err);
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+}
 
 // panic selector
 pub const PANIC_SIG: &str = "Panic(uint256)";
@@ -63,9 +120,10 @@ impl AbiDecodedErrorType {
         Ok(selectors.get(&selector_hash).cloned())
     }
 
-    /// decodes an error returned from calling a contract by searching its selector in registry
-    pub async fn selector_registry_abi_decode(
+    /// Decode an error using an injected registry for selector lookups.
+    pub async fn decode_with_registry(
         error_data: &[u8],
+        registry: &dyn ErrorRegistry,
     ) -> Result<Self, AbiDecodeFailedErrors> {
         if error_data.is_empty() {
             return Err(AbiDecodeFailedErrors::NoData);
@@ -76,7 +134,6 @@ impl AbiDecodedErrorType {
             ));
         }
         let (hash_bytes, args_data) = error_data.split_at(4);
-        let selector_hash = alloy::primitives::hex::encode_prefixed(hash_bytes);
         let selector_hash_bytes: [u8; 4] = hash_bytes
             .try_into()
             .map_err(|_| AbiDecodeFailedErrors::InvalidSelectorHash(hash_bytes.to_vec()))?;
@@ -99,44 +156,33 @@ impl AbiDecodedErrorType {
             }
             return Ok(Self::Unknown(error_data.to_vec()));
         }
-
-        let client = Client::builder().build()?;
-        let response = client
-            .get(SELECTOR_REGISTRY_URL)
-            .query(&vec![
-                ("function", selector_hash.as_str()),
-                ("filter", "true"),
-            ])
-            .header("accept", "application/json")
-            .send()
-            .await?
-            .json::<Value>()
-            .await?;
-
-        if let Some(selectors) = response["result"]["function"][selector_hash].as_array() {
-            for opt_selector in selectors {
-                if let Some(selector) = opt_selector["name"].as_str() {
-                    if let Ok(error) = selector.parse::<AlloyError>() {
-                        if let Ok(result) = error.abi_decode_input(args_data) {
-                            // cache the fetched selector
-                            {
-                                let mut cached_selectors = SELECTORS.lock()?;
-                                cached_selectors.insert(selector_hash_bytes, error.clone());
-                            };
-                            return Ok(Self::Known {
-                                sig: error.signature(),
-                                name: error.name,
-                                args: result.iter().map(|v| format!("{:?}", v)).collect(),
-                                data: error_data.to_vec(),
-                            });
-                        }
-                    }
+        // consult the injected registry
+        let candidates = registry.lookup(selector_hash_bytes).await?;
+        for error in candidates {
+            if let Ok(result) = error.abi_decode_input(args_data) {
+                // cache the fetched selector
+                {
+                    let mut cached_selectors = SELECTORS.lock()?;
+                    cached_selectors.insert(selector_hash_bytes, error.clone());
                 }
+                return Ok(Self::Known {
+                    sig: error.signature(),
+                    name: error.name,
+                    args: result.iter().map(|v| format!("{:?}", v)).collect(),
+                    data: error_data.to_vec(),
+                });
             }
-            Ok(Self::Unknown(error_data.to_vec()))
-        } else {
-            Ok(Self::Unknown(error_data.to_vec()))
         }
+
+        Ok(Self::Unknown(error_data.to_vec()))
+    }
+
+    /// Backwards-compatible decode that uses the default OpenChain registry.
+    pub async fn selector_registry_abi_decode(
+        error_data: &[u8],
+    ) -> Result<Self, AbiDecodeFailedErrors> {
+        let registry = OpenChainRegistry::default();
+        Self::decode_with_registry(error_data, &registry).await
     }
 
     /// Decodes an error by checking if it is a Panic(uint256) and returns `None` if
@@ -191,6 +237,25 @@ impl AbiDecodedErrorType {
             err.to_string(),
         ))
     }
+
+    /// Variant of JSON-RPC error decoding that accepts an injected registry.
+    pub async fn try_from_json_rpc_error_with_registry(
+        err: ErrorPayload,
+        registry: &dyn ErrorRegistry,
+    ) -> Result<Self, AbiDecodeFailedErrors> {
+        if err.message.contains("revert") {
+            if let Some(val) = &err.data {
+                let unwrapped: String = serde_json::from_str(val.get()).map_err(|_| {
+                    AbiDecodeFailedErrors::InvalidJsonRpcResponse(val.get().to_string())
+                })?;
+                let decoded_data = decode(unwrapped.as_bytes())?;
+                return Self::decode_with_registry(&decoded_data, registry).await;
+            }
+        }
+        Err(AbiDecodeFailedErrors::InvalidJsonRpcResponse(
+            err.to_string(),
+        ))
+    }
 }
 
 #[derive(Debug, Error)]
@@ -218,12 +283,31 @@ impl<'a> From<PoisonError<MutexGuard<'a, HashMap<[u8; 4], AlloyError>>>> for Abi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use serde_json::value::RawValue;
+
+    struct FakeRegistry;
+
+    #[async_trait]
+    impl ErrorRegistry for FakeRegistry {
+        async fn lookup(
+            &self,
+            selector: [u8; 4],
+        ) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors> {
+            // 0x1ac66908
+            if selector == [0x1a, 0xc6, 0x69, 0x08] {
+                let e: AlloyError = "UnexpectedOperandValue()".parse().unwrap();
+                Ok(vec![e])
+            } else {
+                Ok(vec![])
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_error_decoder() {
         let data = vec![26, 198, 105, 8];
-        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data.clone())
+        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
             .await
             .expect("failed to get error selector");
         assert_eq!(
@@ -240,7 +324,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_unknown() {
         let data = vec![26, 198, 105, 9];
-        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data.clone())
+        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
             .await
             .expect("failed to get error selector");
         assert_eq!(AbiDecodedErrorType::Unknown(data), res);
@@ -249,7 +333,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_invalid_selector() {
         let data = vec![26, 198, 105];
-        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data.clone())
+        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
             .await
             .expect_err("expected error");
         match res {
@@ -261,7 +345,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_no_data() {
         let data = vec![];
-        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data.clone())
+        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
             .await
             .expect_err("expected error");
         match res {
@@ -273,7 +357,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_cache() {
         let data = vec![26, 198, 105, 8];
-        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data.clone())
+        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
             .await
             .expect("failed to get error selector");
         assert_eq!(
@@ -308,11 +392,14 @@ mod tests {
     async fn test_error_decoder_json_rpc_error() {
         let data = vec![26, 198, 105, 8];
         let encoded = encode(&data);
-        let res = AbiDecodedErrorType::try_from_json_rpc_error(ErrorPayload {
-            code: 3,
-            data: Some(RawValue::from_string(format!(r#""{encoded}""#)).unwrap()),
-            message: "execution reverted".into(),
-        })
+        let res = AbiDecodedErrorType::try_from_json_rpc_error_with_registry(
+            ErrorPayload {
+                code: 3,
+                data: Some(RawValue::from_string(format!(r#""{encoded}""#)).unwrap()),
+                message: "execution reverted".into(),
+            },
+            &FakeRegistry,
+        )
         .await
         .expect("failed to get error selector");
         assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,10 +125,11 @@ impl AbiDecodedErrorType {
         Ok(selectors.get(&selector_hash).cloned())
     }
 
-    /// Decode an error using an injected registry for selector lookups.
-    pub async fn decode_with_registry(
+    /// Decode an error selector with optional registry injection.
+    /// If `registry` is `None`, uses the default OpenChain-backed registry.
+    pub async fn selector_registry_abi_decode(
         error_data: &[u8],
-        registry: &dyn ErrorRegistry,
+        registry: Option<&dyn ErrorRegistry>,
     ) -> Result<Self, AbiDecodeFailedErrors> {
         if error_data.is_empty() {
             return Err(AbiDecodeFailedErrors::NoData);
@@ -161,7 +162,13 @@ impl AbiDecodedErrorType {
             }
             return Ok(Self::Unknown(error_data.to_vec()));
         }
-        // consult the injected registry
+
+        let registry = match registry {
+            Some(r) => r,
+            None => &*DEFAULT_REGISTRY as &dyn ErrorRegistry,
+        };
+
+        // consult the registry
         let candidates = registry.lookup(selector_hash_bytes).await?;
         for error in candidates {
             if let Ok(result) = error.abi_decode_input(args_data) {
@@ -180,13 +187,6 @@ impl AbiDecodedErrorType {
         }
 
         Ok(Self::Unknown(error_data.to_vec()))
-    }
-
-    /// Backwards-compatible decode that uses the default OpenChain registry.
-    pub async fn selector_registry_abi_decode(
-        error_data: &[u8],
-    ) -> Result<Self, AbiDecodeFailedErrors> {
-        Self::decode_with_registry(error_data, &*DEFAULT_REGISTRY).await
     }
 
     /// Decodes an error by checking if it is a Panic(uint256) and returns `None` if
@@ -234,7 +234,7 @@ impl AbiDecodedErrorType {
                     AbiDecodeFailedErrors::InvalidJsonRpcResponse(val.get().to_string())
                 })?;
                 let decoded_data = decode(unwrapped.as_bytes())?;
-                return Self::selector_registry_abi_decode(&decoded_data).await;
+                return Self::selector_registry_abi_decode(&decoded_data, None).await;
             }
         }
         Err(AbiDecodeFailedErrors::InvalidJsonRpcResponse(
@@ -253,7 +253,7 @@ impl AbiDecodedErrorType {
                     AbiDecodeFailedErrors::InvalidJsonRpcResponse(val.get().to_string())
                 })?;
                 let decoded_data = decode(unwrapped.as_bytes())?;
-                return Self::decode_with_registry(&decoded_data, registry).await;
+                return Self::selector_registry_abi_decode(&decoded_data, Some(registry)).await;
             }
         }
         Err(AbiDecodeFailedErrors::InvalidJsonRpcResponse(
@@ -311,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder() {
         let data = vec![26, 198, 105, 8];
-        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
+        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data, Some(&FakeRegistry))
             .await
             .expect("failed to get error selector");
         assert_eq!(
@@ -328,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_unknown() {
         let data = vec![26, 198, 105, 9];
-        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
+        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data, Some(&FakeRegistry))
             .await
             .expect("failed to get error selector");
         assert_eq!(AbiDecodedErrorType::Unknown(data), res);
@@ -337,7 +337,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_invalid_selector() {
         let data = vec![26, 198, 105];
-        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
+        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data, Some(&FakeRegistry))
             .await
             .expect_err("expected error");
         match res {
@@ -349,7 +349,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_no_data() {
         let data = vec![];
-        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
+        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data, Some(&FakeRegistry))
             .await
             .expect_err("expected error");
         match res {
@@ -363,7 +363,7 @@ mod tests {
         // ensure cache is empty for this test
         clear_cache();
         let data = vec![26, 198, 105, 8];
-        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
+        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data, Some(&FakeRegistry))
             .await
             .expect("failed to get error selector");
         assert_eq!(
@@ -560,7 +560,7 @@ mod tests {
         let data = vec![0x1a, 0xc6, 0x69, 0x08];
 
         let registry = OpenChainRegistry::default();
-        let res = AbiDecodedErrorType::decode_with_registry(&data, &registry)
+        let res = AbiDecodedErrorType::selector_registry_abi_decode(&data, Some(&registry))
             .await
             .expect("OpenChain lookup failed");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub const SELECTOR_REGISTRY_URL: &str = "https://api.openchain.xyz/signature-dat
 ///
 /// Implement this trait to provide alternative lookup sources
 /// (e.g. local cache, different HTTP service, bundled table).
-#[async_trait]
+#[async_trait(?Send)]
 pub trait ErrorRegistry: Send + Sync {
     /// Lookup candidate ABI errors for a given 4-byte selector.
     async fn lookup(&self, selector: [u8; 4]) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors>;
@@ -34,13 +34,13 @@ pub struct OpenChainRegistry {
 impl Default for OpenChainRegistry {
     fn default() -> Self {
         Self {
-            client: Client::builder().build().expect("reqwest client"),
+            client: Client::new(),
             url: SELECTOR_REGISTRY_URL.to_string(),
         }
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl ErrorRegistry for OpenChainRegistry {
     async fn lookup(&self, selector: [u8; 4]) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors> {
         let selector_hash = alloy::primitives::hex::encode_prefixed(selector);
@@ -288,7 +288,7 @@ mod tests {
 
     struct FakeRegistry;
 
-    #[async_trait]
+    #[async_trait(?Send)]
     impl ErrorRegistry for FakeRegistry {
         async fn lookup(
             &self,

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use std::{
     sync::{Mutex, MutexGuard, PoisonError},
 };
 use thiserror::Error;
+use url::Url;
 
 pub const SELECTOR_REGISTRY_URL: &str = "https://api.openchain.xyz/signature-database/v1/lookup";
 
@@ -28,14 +29,14 @@ pub trait ErrorRegistry: Send + Sync {
 /// Default OpenChain-backed registry implementation.
 pub struct OpenChainRegistry {
     client: Client,
-    url: String,
+    url: Url,
 }
 
 impl Default for OpenChainRegistry {
     fn default() -> Self {
         Self {
             client: Client::new(),
-            url: SELECTOR_REGISTRY_URL.to_string(),
+            url: Url::parse(SELECTOR_REGISTRY_URL).unwrap(),
         }
     }
 }
@@ -47,7 +48,7 @@ impl ErrorRegistry for OpenChainRegistry {
         let selector_hash = alloy::primitives::hex::encode_prefixed(selector);
         let response = self
             .client
-            .get(&self.url)
+            .get(self.url.as_ref())
             .query(&vec![
                 ("function", selector_hash.as_str()),
                 ("filter", "true"),
@@ -58,17 +59,13 @@ impl ErrorRegistry for OpenChainRegistry {
             .json::<Value>()
             .await?;
 
-        let mut out: Vec<AlloyError> = Vec::new();
-        if let Some(selectors) = response["result"]["function"][selector_hash].as_array() {
-            for opt_selector in selectors {
-                if let Some(name) = opt_selector["name"].as_str() {
-                    if let Ok(err) = name.parse::<AlloyError>() {
-                        out.push(err);
-                    }
-                }
-            }
-        }
-        Ok(out)
+        Ok(response["result"]["function"][selector_hash]
+            .as_array()
+            .into_iter()
+            .flat_map(|selectors| selectors.iter())
+            .filter_map(|opt_selector| opt_selector["name"].as_str())
+            .filter_map(|name| name.parse::<AlloyError>().ok())
+            .collect())
     }
 }
 
@@ -170,23 +167,27 @@ impl AbiDecodedErrorType {
 
         // consult the registry
         let candidates = registry.lookup(selector_hash_bytes).await?;
-        for error in candidates {
-            if let Ok(result) = error.abi_decode_input(args_data) {
+        Ok(candidates
+            .into_iter()
+            .find_map(|error| {
+                let result = error.abi_decode_input(args_data).ok()?;
+
                 // cache the fetched selector
-                {
-                    let mut cached_selectors = SELECTORS.lock()?;
-                    cached_selectors.insert(selector_hash_bytes, error.clone());
-                }
-                return Ok(Self::Known {
+                let mut cached_selectors = match SELECTORS.lock() {
+                    Ok(lock) => lock,
+                    Err(e) => return Some(Err(e)),
+                };
+                cached_selectors.insert(selector_hash_bytes, error.clone());
+
+                Some(Ok(Self::Known {
                     sig: error.signature(),
                     name: error.name,
                     args: result.iter().map(|v| format!("{:?}", v)).collect(),
                     data: error_data.to_vec(),
-                });
-            }
-        }
-
-        Ok(Self::Unknown(error_data.to_vec()))
+                }))
+            })
+            .transpose()?
+            .unwrap_or_else(|| Self::Unknown(error_data.to_vec())))
     }
 
     /// Decodes an error by checking if it is a Panic(uint256) and returns `None` if

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,6 @@ use alloy::json_abi::Error as AlloyError;
 use alloy::primitives::hex::{decode, encode, encode_prefixed, FromHexError};
 use alloy::primitives::U256;
 use alloy::rpc::json_rpc::ErrorPayload;
-use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use reqwest::{Client, Error as ReqwestError};
 use serde_json::Value;
@@ -19,7 +18,8 @@ pub const SELECTOR_REGISTRY_URL: &str = "https://api.openchain.xyz/signature-dat
 ///
 /// Implement this trait to provide alternative lookup sources
 /// (e.g. local cache, different HTTP service, bundled table).
-#[async_trait(?Send)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub trait ErrorRegistry: Send + Sync {
     /// Lookup candidate ABI errors for a given 4-byte selector.
     async fn lookup(&self, selector: [u8; 4]) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors>;
@@ -40,7 +40,8 @@ impl Default for OpenChainRegistry {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl ErrorRegistry for OpenChainRegistry {
     async fn lookup(&self, selector: [u8; 4]) -> Result<Vec<AlloyError>, AbiDecodeFailedErrors> {
         let selector_hash = alloy::primitives::hex::encode_prefixed(selector);
@@ -78,6 +79,10 @@ pub const PANIC_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71]; // 0x4e487b71
 /// hashmap of cached error selectors
 pub static SELECTORS: Lazy<Mutex<HashMap<[u8; 4], AlloyError>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Default registry instance reused across calls to avoid repeatedly
+/// constructing a reqwest::Client.
+pub static DEFAULT_REGISTRY: Lazy<OpenChainRegistry> = Lazy::new(OpenChainRegistry::default);
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Error)]
 pub enum AbiDecodedErrorType {
@@ -181,8 +186,7 @@ impl AbiDecodedErrorType {
     pub async fn selector_registry_abi_decode(
         error_data: &[u8],
     ) -> Result<Self, AbiDecodeFailedErrors> {
-        let registry = OpenChainRegistry::default();
-        Self::decode_with_registry(error_data, &registry).await
+        Self::decode_with_registry(error_data, &*DEFAULT_REGISTRY).await
     }
 
     /// Decodes an error by checking if it is a Panic(uint256) and returns `None` if
@@ -283,12 +287,12 @@ impl<'a> From<PoisonError<MutexGuard<'a, HashMap<[u8; 4], AlloyError>>>> for Abi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use serde_json::value::RawValue;
 
     struct FakeRegistry;
 
-    #[async_trait(?Send)]
+    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
     impl ErrorRegistry for FakeRegistry {
         async fn lookup(
             &self,
@@ -307,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder() {
         let data = vec![26, 198, 105, 8];
-        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
+        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
             .await
             .expect("failed to get error selector");
         assert_eq!(
@@ -324,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_unknown() {
         let data = vec![26, 198, 105, 9];
-        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
+        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
             .await
             .expect("failed to get error selector");
         assert_eq!(AbiDecodedErrorType::Unknown(data), res);
@@ -333,7 +337,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_invalid_selector() {
         let data = vec![26, 198, 105];
-        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
+        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
             .await
             .expect_err("expected error");
         match res {
@@ -345,7 +349,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_decoder_no_data() {
         let data = vec![];
-        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
+        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
             .await
             .expect_err("expected error");
         match res {
@@ -356,8 +360,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_decoder_cache() {
+        // ensure cache is empty for this test
+        clear_cache();
         let data = vec![26, 198, 105, 8];
-        let res = AbiDecodedErrorType::decode_with_registry(&data.clone(), &FakeRegistry)
+        let res = AbiDecodedErrorType::decode_with_registry(&data, &FakeRegistry)
             .await
             .expect("failed to get error selector");
         assert_eq!(
@@ -386,6 +392,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(None, res);
+    }
+
+    fn clear_cache() {
+        let mut cache = SELECTORS
+            .lock()
+            .expect("failed to lock selectors cache for clearing");
+        cache.clear();
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -552,4 +552,31 @@ mod tests {
             res
         );
     }
+
+    #[tokio::test]
+    async fn test_openchain_registry_live_lookup_known_selector() {
+        clear_cache();
+
+        let data = vec![0x1a, 0xc6, 0x69, 0x08];
+
+        let registry = OpenChainRegistry::default();
+        let res = AbiDecodedErrorType::decode_with_registry(&data, &registry)
+            .await
+            .expect("OpenChain lookup failed");
+
+        match res {
+            AbiDecodedErrorType::Known {
+                name,
+                args,
+                sig,
+                data: decoded,
+            } => {
+                assert_eq!(decoded, data);
+                assert!(args.is_empty(), "expected zero-arg error match");
+                assert!(!name.is_empty(), "expected non-empty error name");
+                assert!(sig.ends_with(')'), "expected error-like signature");
+            }
+            AbiDecodedErrorType::Unknown(_) => panic!("expected a known error from OpenChain"),
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issues:

- https://github.com/rainlanguage/rain.error/issues/19

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Added ErrorRegistry trait with an async lookup method.
- Added OpenChainRegistry default implementation that calls the OpenChain API
- Kept selector_registry_abi_decode as a wrapper that uses the default OpenChainRegistry for backward compatibility
- Updated tests to use a fake registry

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensible error registry with a default remote-backed lookup and support for custom registry implementations.
  * Registry-aware JSON-RPC error decoding to resolve richer error details via injected registries.

* **Refactor**
  * Error decoding flow reworked to accept injected registries and cache lookup results while preserving prior behavior.

* **Tests**
  * Tests updated to exercise registry injection, caching, and the registry-aware decoding using a fake registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->