### PR TITLE
chore: latest rainix + soldeer re-lock

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
   URL=https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc
   HASH=sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM=

--- a/.github/workflows/pr-assessment.yaml
+++ b/.github/workflows/pr-assessment.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       - closed
-
 jobs:
   assess-pr-size-on-merge:
     uses: rainlanguage/github-chore/.github/workflows/pr-assessment.yml@main

--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1779806489,
-        "narHash": "sha256-JbklaRxO10LMCRerXySnPeSUyMWLPB+uTEkg+CUj/AU=",
+        "lastModified": 1780287289,
+        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "0aa21cdf03642e7cf2b0f4151a943d39b314fde3",
+        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps rainix to latest and re-locks soldeer deps.

- `rainix.url` -> `github:rainlanguage/rainix`, `nix flake update rainix`
- soldeer deps bumped to latest registry versions where behind, then re-locked
- verified via `nix develop` (latest rainix dev shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)